### PR TITLE
feat: update STS trust policy for release-please

### DIFF
--- a/.github/chainguard/release-please.sts.yaml
+++ b/.github/chainguard/release-please.sts.yaml
@@ -7,3 +7,4 @@ permissions:
   contents: write
   issues: write
   pull_requests: write
+  packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,12 @@ jobs:
   docker:
     runs-on: ubuntu-24.04-arm
     steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: jburns24/five31
+          identity: release-please
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -36,7 +42,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.octo-sts.outputs.token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
change the token used for package publishing to use STS after reading reports that reusing a repo name can cause issues with permissions on the GITHUB_TOKEN.