### PR TITLE
fix: respect explicit workout selection instead of always redirecting to first incomplete

### DIFF
--- a/app/workout/page.tsx
+++ b/app/workout/page.tsx
@@ -97,17 +97,11 @@ function WorkoutPageContent() {
       if (isAllWorkoutsComplete(typedWorkouts)) {
         setAllComplete(true);
       } else {
-        // Always navigate to first incomplete workout on page load
-        const firstIncomplete = findFirstIncompleteWorkout(typedWorkouts);
-        if (firstIncomplete) {
-          const currentWeekFromUrl = weekParam ? parseInt(weekParam, 10) : null;
-          const currentLiftFromUrl = liftParam as LiftType | null;
-
-          // Only navigate if current URL doesn't match first incomplete
-          if (
-            currentWeekFromUrl !== firstIncomplete.weekNumber ||
-            currentLiftFromUrl !== firstIncomplete.lift
-          ) {
+        // Only auto-navigate to first incomplete when no explicit workout was requested
+        const hasExplicitSelection = weekParam !== null || liftParam !== null;
+        if (!hasExplicitSelection) {
+          const firstIncomplete = findFirstIncompleteWorkout(typedWorkouts);
+          if (firstIncomplete) {
             const params = new URLSearchParams();
             params.set('week', firstIncomplete.weekNumber.toString());
             params.set('lift', firstIncomplete.lift);


### PR DESCRIPTION
When a user navigates to a specific workout via URL params (?week=X&lift=Y),
the page no longer overrides that selection by redirecting to the first
incomplete workout. Auto-navigation to first incomplete only fires on bare
/workout URLs with no explicit selection.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
