### PR TITLE
fix(ci): switch release-please to manifest mode so extra-files runs

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           # Using octo-sts to get a temporarty token. Needed so this workflow
           # will trigger other workflows (ie: the tag pushed by this workflow will trigger release.yaml)
           token: ${{ steps.octo-sts.outputs.token }}
-          release-type: 'simple'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: five31
-          image: ghcr.io/jburns24/five31:v1.3.0 # x-release-please-version
+          image: ghcr.io/jburns24/five31:v1.3.1 # x-release-please-version
           ports:
             - containerPort: 3000
           envFrom:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,14 +2,13 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-v-in-tag": true,
-  "packages": {
-    ".": {
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "k8s/deployment.yaml"
-        }
-      ]
+  "extra-files": [
+    {
+      "type": "generic",
+      "path": "k8s/deployment.yaml"
     }
+  ],
+  "packages": {
+    ".": {}
   }
 }


### PR DESCRIPTION
The workflow passed both `config-file` and `release-type: 'simple'`. Setting
`release-type` puts release-please-action into non-manifest mode, where it
ignores the `packages` block of the config file — so the per-package
`extra-files` entry pointing at `k8s/deployment.yaml` was silently dropped
and v1.3.1 shipped without bumping the manifest's image pin.

Changes:
- Remove `release-type: 'simple'` from the workflow input; the same value
  remains as the top-level default in `release-please-config.json`.
- Add explicit `manifest-file:` so the workflow's intent is unambiguous.
- Move `extra-files` to top level of `release-please-config.json` (also
  documented to work, removes the per-package nesting that surprised us).
- Bump `k8s/deployment.yaml` image pin from v1.3.0 to v1.3.1 to clear the
  drift introduced by the broken release.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
